### PR TITLE
Provide 4th arg to `Plugin::new(...)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,5 +226,6 @@ pub fn perseus_size_opt<G: GenericNode>() -> Plugin<G, SizeOpts> {
             actions
         },
         empty_control_actions_registrar,
+        true,
     )
 }


### PR DESCRIPTION
Provide the fourth argument with the value of `true` in order to make the plugin compatible with Perseus version `0.3.0-beta.14`